### PR TITLE
removing version requirement from metadata.json

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -57,7 +57,7 @@ define supervisor::service(
           start => "/usr/bin/supervisorctl start ${name}",
           status => "/usr/bin/supervisorctl status | awk '/^${name}/{print \$2}' | grep '^RUNNING$'",
           stop => "/usr/bin/supervisorctl stop ${name}",
-          require => [ Package["supervisor"], Service["supervisor"], $require ];
+          require => [ Package["supervisor"], Service["supervisor"] ];
       }
     }
   }


### PR DESCRIPTION
I think the module should be fine on just about any version >= than 0.2.4.  Here's a list of manifest features by version:
http://docs.puppetlabs.com/guides/language_guide.html

Unfortunately, it doesn't seem  like it's possible to specify a greater than operator for the version inside metadata.json. Unless you have a better idea, removing the version requirement might be the best bet.
