### PR TITLE
Feature/decoupling

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -48,7 +48,7 @@ define supervisor::service(
           default => false };
     }
 
-    if $ensure == 'running' {
+    if ($ensure == 'running' or $ensure == 'stopped') {
       service {
         "supervisor::${name}":
           ensure   => $ensure,


### PR DESCRIPTION
So this change (from my limited testing):
1. Changes the default ensure parameter in the define, which enables us to:
2. Decouple the service from the type.

Let me explain a bit:

Sometimes you want your services _configuration_ to be controlled by puppet, whereas you don't want your services _state_ to be controlled by puppet. If you want puppet to manage supervisor services as any other init.d service, just use "ensure => running" or "ensure => stopped". However, if you want puppet to leave your supervisor service stopped if you stopped it manually, don't do anything: defaults to "present" and so the service is not created.

Thoughts?
