### PR TITLE
Remove superfluous 'modules' in puppet file path.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,10 @@ class supervisor {
       ensure  => directory,
       purge   => true,
       require => Package[$supervisor::params::package];
+    $supervisor::params::ini_dir:
+      ensure  => directory,
+      purge   => true,
+      require => File[$supervisor::params::conf_dir];
     ['/var/log/supervisor',
      '/var/run/supervisor']:
       ensure  => directory,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class supervisor::params {
     'ubuntu','debian': {
       $conf_file = '/etc/supervisor/supervisord.conf'
       $conf_dir = '/etc/supervisor'
+      $conf_ext = 'conf'
       $ini_dir = "${conf_dir}/conf.d"
       $system_service = 'supervisor'
       $package = 'supervisor'
@@ -10,6 +11,7 @@ class supervisor::params {
     'centos','fedora','redhat': {
       $conf_file = '/etc/supervisord.conf'
       $conf_dir = '/etc/supervisor.d'
+      $conf_ext = 'ini'
       $ini_dir = $conf_dir
       $system_service = 'supervisord'
       $package = 'supervisor'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,7 +19,7 @@ define supervisor::service(
     }
 
     file {
-      "${supervisor::params::ini_dir}/${name}.ini":
+      "${supervisor::params::ini_dir}/${name}.${supervisor::params::conf_ext}":
         ensure => $enable ? {
           false => absent,
           default => undef },

--- a/templates/supervisord.conf.erb
+++ b/templates/supervisord.conf.erb
@@ -19,4 +19,4 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [include]
-files = <%= scope.lookupvar('supervisor::params::ini_dir') -%>/*.ini
+files = <%= scope.lookupvar('supervisor::params::ini_dir') -%>/*.<%= scope.lookupvar('supervisor::params::conf_ext') %>


### PR DESCRIPTION
Exactly how puppet converts ambiguous paths into absolute paths I'm not entirely
sure. I _am_ sure, however, that the path modified that this commit resolved
into:

```
/etc/puppet/modules/modules/files/supervisor/logrotate
```

where the new path resolves to

   /etc/puppet/modules/modules/supervisor/files/logrotate

The later, of course, being correct.

Signed-off-by: Brian L. Troutwine brian@troutwine.us
