### PR TITLE
Rename loglevel to log_level

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,7 +105,7 @@ class supervisor(
   $logfile = '/var/log/supervisor/supervisord.log',
   $logfile_maxbytes = '500MB',
   $logfile_backups = 10,
-  $loglevel = 'info',
+  $log_level = 'info',
   $minfds = 1024,
   $minprocs = 200,
   $childlogdir = '/var/log/supervisor',

--- a/templates/supervisord.conf.erb
+++ b/templates/supervisord.conf.erb
@@ -14,7 +14,7 @@ pass=<%= inet_server_pass %>
 logfile=<%= logfile %>                      ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=<%= logfile_maxbytes %>    ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=<%= logfile_backups %>      ; (num of main logfile rotation backups;default 10)
-loglevel=<%= loglevel %>                    ; (log level;default info; others: debug,warn,trace)
+loglevel=<%= log_level %>                    ; (log level;default info; others: debug,warn,trace)
 pidfile=/var/run/supervisord.pid            ; (supervisord pidfile;default supervisord.pid)
 nodaemon=false                              ; (start in foreground if true;default false)
 minfds=<%= minfds %>                        ; (min. avail startup file descriptors;default 1024)


### PR DESCRIPTION
loglevel is a reserved word (metaparameter) in Puppet
http://docs.puppetlabs.com/references/2.7.9/metaparameter.html

The practical problem, here, is that if we pass a loglevel = "trace" (which is a legitimate log level in supervisor), puppet complains with:

```
err: Failed to apply catalog: Parameter loglevel failed: Invalid value "trace". Valid values are debug, info, notice, warning, err, alert, emerg, crit, verbose.
```

This patch simply changes loglevel to log_level.
It is a BC break, but… well… it was already broken.
