### PR TITLE
add missing doc for recurse_config_dir parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,10 @@
 #     used by the RPC interface.
 #     Default: undef
 #
+#   [*recurse_config_dir*]
+#     Remove unmanaged files from config directory.
+#     Default: false
+#
 # Actions:
 #   Installs supervisor.
 #


### PR DESCRIPTION
I've forgotten to add the documentation for recurse_config_dir parameter in my last commit
