### PR TITLE
Change package provider to pip

### DIFF
--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -1,0 +1,8 @@
+description     "supervisor"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+exec /usr/local/bin/supervisord --nodaemon --configuration /etc/supervisord.conf

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,7 +157,8 @@ class supervisor(
 
   if ! defined(Package[$supervisor::params::package]) {
     package { $supervisor::params::package:
-      ensure => $package_ensure,
+      ensure   => $package_ensure,
+      provider => pip,
     }
   }
 
@@ -165,6 +166,12 @@ class supervisor(
     ensure  => $dir_ensure,
     purge   => true,
     recurse => $recurse_config_dir,
+    require => Package[$supervisor::params::package],
+  }
+
+  file { $supervisor::params::init_file:
+    ensure  => $file_ensure,
+    source  => 'puppet:///modules/supervisor/supervisord.conf',
     require => Package[$supervisor::params::package],
   }
 
@@ -195,6 +202,6 @@ class supervisor(
     ensure     => $service_ensure_real,
     enable     => $service_enable,
     hasrestart => true,
-    require    => File[$supervisor::params::conf_file],
+    require    => File[$supervisor::params::conf_file, $supervisor::params::init_file],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,19 +1,7 @@
 class supervisor::params {
-  case $::operatingsystem {
-    'ubuntu','debian': {
-      $conf_file      = '/etc/supervisor/supervisord.conf'
-      $conf_dir       = '/etc/supervisor'
-      $system_service = 'supervisor'
-      $package        = 'supervisor'
-    }
-    'centos','fedora','redhat': {
-      $conf_file      = '/etc/supervisord.conf'
-      $conf_dir       = '/etc/supervisord.d'
-      $system_service = 'supervisord'
-      $package        = 'supervisor'
-    }
-    default: {
-      fail("Unsupported platform: ${::operatingsystem}")
-    }
-  }
+    $conf_file      = '/etc/supervisord.conf'
+    $conf_dir       = '/etc/supervisord.d'
+    $system_service = 'supervisord'
+    $package        = 'supervisor'
+    $init_file      = '/etc/init/supervisord.conf'
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,6 +24,8 @@ define supervisor::service (
   $stopsignal               = 'TERM',
   $stopwait                 = 10,
   $user                     = 'root',
+  $stopasgroup              = false,
+  $killasgroup              = false,
   $group                    = 'root',
   $redirect_stderr          = false,
   $directory                = undef,
@@ -90,10 +92,10 @@ define supervisor::service (
   service { "supervisor::${name}":
     ensure   => $service_ensure,
     provider => base,
-    restart  => "/usr/bin/supervisorctl restart ${process_name}",
-    start    => "/usr/bin/supervisorctl start ${process_name}",
-    status   => "/usr/bin/supervisorctl status | awk '/^${name}[: ]/{print \$2}' | grep '^RUNNING$'",
-    stop     => "/usr/bin/supervisorctl stop ${process_name}",
+    restart  => "/usr/local/bin/supervisorctl restart ${process_name}",
+    start    => "/usr/local/bin/supervisorctl start ${process_name}",
+    status   => "/usr/local/bin/supervisorctl status | awk '/^${name}[: ]/{print \$2}' | grep '^RUNNING$'",
+    stop     => "/usr/local/bin/supervisorctl stop ${process_name}",
     require  => File["${supervisor::params::conf_dir}/${name}.ini"],
   }
 }

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,6 +1,6 @@
 class supervisor::update {
   exec { 'supervisor::update':
-    command     => '/usr/bin/supervisorctl update',
+    command     => '/usr/local/bin/supervisorctl update',
     logoutput   => on_failure,
     refreshonly => true,
     require     => Service[$supervisor::params::system_service],

--- a/templates/service.ini.erb
+++ b/templates/service.ini.erb
@@ -20,6 +20,8 @@ directory=<%= directory %>
 <% if @user -%>
 user=<%= user %>
 <% end -%>
+stopasgroup=<%= stopasgroup %>
+killasgroup=<%= killasgroup %>
 redirect_stderr=<%= redirect_stderr %>
 <% if @stdout_logfile -%>
 stdout_logfile=<%= stdout_logfile %>


### PR DESCRIPTION
1. use upstart to manage service.
2. use pip instead of apt to use a newer version of supervisor.
3. add killasgroup and stopasgroup options.

---

FYI, I only tested it on Ubuntu.

The package from default apt provider is 3.0a8 which is a little old and don't have killasgroup/stopasgroup options. So I made a little refine to use pip as provider.

I'm not familiar with other OS so I choose to use upstart which is the recommend way for ubuntu, and it may not work for other OS. So it may need some other tweaks before merge, just a suggestion here.
