### PR TITLE
Switch to osfamily from operatingsystem to support SL, OEL, etc

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,12 +1,12 @@
 class supervisor::params {
-  case $::operatingsystem {
-    'ubuntu','debian': {
+  case $::osfamily {
+    'debian': {
       $conf_file      = '/etc/supervisor/supervisord.conf'
       $conf_dir       = '/etc/supervisor'
       $system_service = 'supervisor'
       $package        = 'supervisor'
     }
-    'centos','fedora','redhat': {
+    'redhat': {
       $conf_file      = '/etc/supervisord.conf'
       $conf_dir       = '/etc/supervisord.d'
       $system_service = 'supervisord'


### PR DESCRIPTION
This commit moves the operatingsystem check to use osfamily instead - this is needed to support Redhat based OS's you do not check in the conditional.
