### PR TITLE
Add update dependency to service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -94,6 +94,6 @@ define supervisor::service (
     start    => "/usr/bin/supervisorctl start ${process_name}",
     status   => "/usr/bin/supervisorctl status | awk '/^${name}[: ]/{print \$2}' | grep '^RUNNING$'",
     stop     => "/usr/bin/supervisorctl stop ${process_name}",
-    require  => File["${supervisor::params::conf_dir}/${name}.ini"],
+    require  => [Class['supervisor::update'], File["${supervisor::params::conf_dir}/${name}.ini"]],
   }
 }


### PR DESCRIPTION
I had trouble while running puppet the first time with some services configured. Seems like the module tried to start the services before running supervisor::update. 

Environment: I'm running Debian squeeze with puppet v3.1.0 in vagrant.

Here is my puppet log snippet:
Notice: /Stage[main]/Supervisor/Package[supervisor]/ensure: ensure changed 'purged' to 'present'
Notice: /Stage[main]/Supervisor/File[/var/run/supervisor]/ensure: created
Notice: /Stage[main]/Supervisor/File[/etc/logrotate.d/supervisor]/ensure: defined content as '{md5}1ebbf5e2b3cc73ad22b7483d8d469a3d'
Notice: /Stage[main]/Supervisor/File[/etc/supervisor/supervisord.conf]/content: content changed '{md5}0621b69ff19bcd753a7543e867ef7b9a' to '{md5}5d65ff73aecb28806bb500a899d4c036'
Error: /Stage[main]/Supervisor/Service[supervisor]: Failed to call refresh: Could not restart Service[supervisor]: Execution of '/etc/init.d/supervisor restart' returned 1:

Error: /Stage[main]/Supervisor/Service[supervisor]: Could not restart Service[supervisor]: Execution of '/etc/init.d/supervisor restart' returned 1:
Notice: /Stage[main]/MYMODULE/Supervisor::Service[premium]/File[/var/log/supervisor/premium]/ensure: created
Notice: /Stage[main]/MYMODULE/Supervisor::Service[standard]/File[/var/log/supervisor/standard]/ensure: created
Notice: /Stage[main]/MYMODULE/Supervisor::Service[standard]/File[/etc/supervisor/standard.ini]/ensure: defined content as '{md5}5f8da31726e5a017344dc6922f2fa7e5'
Notice: /Stage[main]/MYMODULE/Supervisor::Service[premium]/File[/etc/supervisor/premium.ini]/ensure: defined content as '{md5}04a1bb88072b50aa3a62a1355352afab'
Notice: /Stage[main]/MYMODULE/Supervisor::Service[premium]/Service[supervisor::premium]/ensure: ensure changed 'stopped' to 'running'
Error: Could not start Service[supervisor::standard]: Execution of '/usr/bin/supervisorctl start standard:*' returned 2:

Error: /Stage[main]/MYMODULE/Supervisor::Service[standard]/Service[supervisor::standard]/ensure: change from stopped to running failed: Could not start Service[supervisor::standard]: Execution of '/usr/bin/supervisorctl start standard:*' returned 2:
Notice: /Stage[main]/MYMODULE/Supervisor::Service[intern]/File[/var/log/supervisor/intern]/ensure: created
Notice: /Stage[main]/MYMODULE/Supervisor::Service[intern]/File[/etc/supervisor/intern.ini]/ensure: defined content as '{md5}f0a1c90e6e8b46e4da2073f058f0686f'
Notice: /Stage[main]/Supervisor::Update/Exec[supervisor::update]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/MYMODULE/Supervisor::Service[intern]/Service[supervisor::intern]/ensure: ensure changed 'stopped' to 'running'
