### PR TITLE
make start/stop/restart return sensible error codes too, like status

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -90,10 +90,10 @@ define supervisor::service (
   service { "supervisor::${name}":
     ensure   => $service_ensure,
     provider => base,
-    restart  => "/usr/bin/supervisorctl restart ${process_name}",
-    start    => "/usr/bin/supervisorctl start ${process_name}",
+    restart  => "/usr/bin/supervisorctl restart ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep -Pzo '^stopped\nstarted$'",
+    start    => "/usr/bin/supervisorctl start ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep '^started$'",
     status   => "/usr/bin/supervisorctl status | awk '/^${name}[: ]/{print \$2}' | grep '^RUNNING$'",
-    stop     => "/usr/bin/supervisorctl stop ${process_name}",
+    stop     => "/usr/bin/supervisorctl stop ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep '^stopped$'",
     require  => [Class['supervisor::update'], File["${supervisor::params::conf_dir}/${name}.ini"]],
   }
 }


### PR DESCRIPTION
supervisorctl appears to return "0" all the time, not just for the status command. This means that puppet can't tell when the service failed to start, or failed to stop. It will of course try again next time puppet runs, but you'll never get a report of the problem.

I followed the pattern already set for "status". The only one that's a little weird is "restart", because it's multi-line. This is fairly simple to resolve with "grep -Pzo", but other methods exist too... sed or awk can probably do this just as well. I'm not sure if there's any good reason to prefer one method over another.
