### PR TITLE
Ensure config file is absent when service is declared absent

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -33,6 +33,7 @@ define supervisor::service (
       $dir_recurse = true
       $dir_force = true
       $service_ensure = 'stopped'
+      $config_ensure = 'absent'
     }
     present: {
       $autostart = true


### PR DESCRIPTION
If `Supervisor::Service['fooservice']` had previously been declared, but now we want to delete the associated supervisor configuration, we should be able to do something like this:

```
supervisor::service { 'fooservice':
    ensure => 'absent',
    command => "/usr/bin/foo",
}
```

However, this would not delete the configuration file `/etc/supervisor/fooservice.init`. This PR fixes that.
