### PR TITLE
Puppet is throwing invalid byte sequence in US-ASCII error because of '

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@
 #
 #   [*supervisor_environment*]
 #     A list of key/value pairs in the form KEY=val,KEY2=val2 that will be
-#     placed in the supervisord process’ environment.
+#     placed in the supervisord process environment.
 #     Default: undef
 #
 #   [*identifier*]


### PR DESCRIPTION
This is on puppet enterprise version 3.0.0.
