### PR TITLE
Invalid single quote within single quote

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -4,7 +4,7 @@ source 'https://github.com/plathrop/puppet-module-supervisor'
 author 'Paul Lathrop <paul@tertiusfamily.net>'
 license '2 clause BSD, see LICENSE'
 summary 'Puppet module to install and configure supervisor'
-description 'Puppet module for configuring the 'supervisor' daemon control utility. Currently tested on Debian, Ubuntu, and Fedora.'
+description "Puppet module for configuring the 'supervisor' daemon control utility. Currently tested on Debian, Ubuntu, and Fedora."
 project_page 'https://github.com/plathrop/puppet-module-supervisor'
 
 ## Add dependencies, if any:


### PR DESCRIPTION
The description line contains a singe quote that is wrapped by a single quote.
Replaced it with double quotes. According to the Puppet manual ( http://docs.puppetlabs.com/puppet/2.7/reference/modules_publishing.html#write-a-modulefile ) it's valid.
