### PR TITLE
Fixed: 'Could not restart Service' error.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -91,7 +91,7 @@ define supervisor::service (
   service { "supervisor::${name}":
     ensure   => $service_ensure,
     provider => base,
-    restart  => "/usr/bin/supervisorctl restart ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep -Pzo '^stopped\nstarted$'",
+    restart  => "/usr/bin/supervisorctl restart ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep -Pzo '^stopped\\nstarted$'",
     start    => "/usr/bin/supervisorctl start ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep '^started$'",
     status   => "/usr/bin/supervisorctl status | awk '/^${name}[: ]/{print \$2}' | grep '^RUNNING$'",
     stop     => "/usr/bin/supervisorctl stop ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep '^stopped$'",


### PR DESCRIPTION
Without this fix, attempting to restart a supervisor service on Ubuntu 12.04 would result in a "Could not restart Service" error, even that the restart was in fact successful. The `\n` in the grep pattern was being actualised by puppet, rather than being made a part of the regex.

This fix makes the `\n` part of the stopped … started regex.

Refs #38.
