### PR TITLE
Higher startsecs causes start failures

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -93,7 +93,7 @@ define supervisor::service (
     provider => base,
     restart  => "/usr/bin/supervisorctl restart ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep -Pzo '^stopped\\nstarted$'",
     start    => "/usr/bin/supervisorctl start ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep '^started$'",
-    status   => "/usr/bin/supervisorctl status | awk '/^${name}[: ]/{print \$2}' | grep '^RUNNING$'",
+    status   => "/usr/bin/supervisorctl status | awk 'BEGIN { RS = \"\\n\" } /^${name}_?\\d*/ { if (\$2 !~ /^(STARTING|RUNNING)/) { exit 1 } }'",
     stop     => "/usr/bin/supervisorctl stop ${process_name} | awk '/^${name}[: ]/{print \$2}' | grep '^stopped$'",
     require  => [Class['supervisor::update'], File["${supervisor::conf_dir}/${name}${supervisor::conf_ext}"]],
   }

--- a/spec/defines/supervisor::service_spec.rb
+++ b/spec/defines/supervisor::service_spec.rb
@@ -42,6 +42,16 @@ describe 'supervisor::service' do
       should create_file('/etc/supervisor/sometitle.ini') \
           .with_content(Regexp.new Regexp.escape 'command=somecommand')
     end
+    it {
+      should contain_service("supervisor::#{title}").with(
+        'ensure'     => 'running',
+        'provider'   => 'base',
+        'restart'    => "/usr/bin/supervisorctl restart sometitle | awk '/^sometitle[: ]/{print \$2}' | grep -Pzo '^stopped\\nstarted$'",
+        'start'      => "/usr/bin/supervisorctl start sometitle | awk '/^sometitle[: ]/{print \$2}' | grep '^started$'",
+        'status'     => "/usr/bin/supervisorctl status | awk 'BEGIN { RS = \"\\n\" } /^sometitle_?\\d*/ { if (\$2 !~ /^(STARTING|RUNNING)/) { exit 1 } }'",
+        'stop'       => "/usr/bin/supervisorctl stop sometitle | awk '/^sometitle[: ]/{print \$2}' | grep '^stopped$'",
+      )
+    }
   end
 
 end


### PR DESCRIPTION
I'm running into an issue where Puppet apply fails because it cannot start the services. It appears this is happening because `startsecs` waits the amount of seconds specified before listing the service status as `RUNNING`. Before running the state is `STARTING`.

This seems to happen between the initial `supervisorctl update` and the service status check. The update is triggered (which in turn starts services with `autostart` set), then the individual service status checks that the process is `RUNNING`. But since `startsecs` has not passed yet, the status is still `STARTING` which causes a failure.

I'm wondering if it makes sense to have the status check for `RUNNING` or `STARTING`? The problem here would be processes that actually fail to start after `startsecs`. Puppet would not catch this case. Any thoughts on how to cover both cases?
