### PR TITLE
Fix restarting problems when changing both supervisord and managed services configs

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -99,6 +99,8 @@ define supervisor::service (
     provider => supervisor,
   }
 
+  Service[$supervisor::params::system_service] -> Service["supervisor::${name}"]
+
   case $ensure {
     'present', 'running', 'stopped': {
       File[$log_dir] -> File[$conf_file] ~>


### PR DESCRIPTION
Puppet fails to restart managed services when both supervisord.conf and configs of managed services has been changed simultaneously. This happens: `/etc/init.d/supervisor restart` and `supervisorctl restart <some_service>` happen simultaneously and  `supervisorctl restart <some_service>` can't connect to shutting down/still starting main processes with a message like 

```
Execution of '/usr/bin/supervisorctl start create_website:*' returned 2: error: <class 'xmlrpclib.Fault'>, <Fault 6: 'SHUTDOWN_STATE'>: file: /usr/lib/python2.6/xmlrpclib.py line: 838
```

The fix is to serialize this two services.
This also fixes #62
