### PR TITLE
Narrow logfile dependency to logdir instead of entire class

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -84,7 +84,7 @@ define supervisor::service (
     mode    => '0750',
     recurse => $dir_recurse,
     force   => $dir_force,
-    require => Class['supervisor'],
+    require => File['/var/log/supervisor'],
   }
 
   $conf_file = "${supervisor::conf_dir}/${name}${supervisor::conf_ext}"


### PR DESCRIPTION
We ran into a situation where we had supervisord stopped, and a typo in one of its services' ini files. Supervisord would fail to start because of the typo, and then puppet would refuse to update the ini file because the service failed to start.

Narrowed it down to this class dependency; supervisor::service has 

```
File[$log_dir] -> File[$conf_file] ~>
    Class['supervisor::update'] -> Service["supervisor::${name}"]
```

and the class dependency of File[$log_dir] means that we really have

```
Class['supervisor'] -> File[$log_dir] -> File[$conf_file] ...
```

which means that if supervisor fails to start, the rest of the chain doesn't run, and so it can't self-heal. Narrowing the dependency means it self-heals in two runs.
