### PR TITLE
Allow service to not be controlled by Puppet

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,7 @@
 #
 define supervisor::service (
   $command,
-  $ensure                   = 'present',
+  $ensure                   = 'running',
   $numprocs                 = 1,
   $numprocs_start           = 0,
   $priority                 = 999,

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -56,6 +56,22 @@ describe 'supervisor::service' do
     end
   end
 
+ context "with ensure => present" do
+   let (:params) { {
+     :command => 'somecommand',
+     :ensure => 'present',
+   } }
+
+   it "should create /etc/supervisor/sometitle.ini" do
+     should create_file('/etc/supervisor/sometitle.ini') \
+         .with_content(Regexp.new Regexp.escape 'command=somecommand')
+   end
+
+   it "should not create service" do
+     should_not contain_service('supervisor::sometitle')
+   end
+ end
+
   context "with ensure => stopped" do
     let (:params) { {
       :command => 'somecommand',
@@ -69,6 +85,22 @@ describe 'supervisor::service' do
 
     it "should ensure that the service is stopped" do
       should contain_service('supervisor::sometitle').with_ensure('stopped')
+    end
+  end
+
+  context "with ensure => running" do
+    let (:params) { {
+      :command => 'somecommand',
+      :ensure => 'running',
+    } }
+
+    it "should create /etc/supervisor/sometitle.ini" do
+      should create_file('/etc/supervisor/sometitle.ini') \
+          .with_content(Regexp.new Regexp.escape 'command=somecommand')
+    end
+
+    it "should ensure that the service is stopped" do
+      should contain_service('supervisor::sometitle').with_ensure('running')
     end
   end
 


### PR DESCRIPTION
Change the ensure => "present" state to not create the "service" resource. Which leaves the service uncontrolled by Puppet, and allows to be not controlled by Puppet.

ensure => "present": Create config and don't control service
ensure => "running", ensure => "stopped": Create config and service with given ensure state.
ensure => "absent": Stop service and remove config

The downside is that it changes the behavior of the default "present" state. I also changed the default state to "running" to preserve default behavior. For compatibility, it might make sense to leave behavior of "present" unchanged and create a new state for the uncontrolled behavior. 

This is an implementation of feature proposed in #76.
