### PR TITLE
Fix status regex to allow process num to be more than 2 digits

### DIFF
--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:service).provide :supervisor, :parent => :base do
     #output.lines.map { |line| line.match /^((?<group_name>.+?):)?(?<process_name>(?<program_name>.+?)(_(?<program_num>\d{2}))?) +(?<state>\w+)/ }.reject(&:nil?)
 
     result = output.lines.map { |line|
-      line.match /^((.+?):)?((.+?)(_(\d{2}))?) +(\w+)/
+      line.match /^((.+?):)?((.+?)(_(\d+))?) +(\w+)/
       { :group_name => $2, :process_name => $3, :program_name => $4, :program_num => $6, :state => $7 }
     }
     result.reject(&:nil?)


### PR DESCRIPTION
group_support branch added regex to parse "supervisorctl status" lines. The regex restricted the process_num to two digits "(_(\d+))?", which causes problem when the process_num is more than two digits (we use port number as process_num for some services).
