### PR TITLE
Modifications for docker compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,10 @@
 #     Ensure if present or absent.
 #     Default: present
 #
+#   [*nodaemon*]
+#     Run supervisord in the foreground.
+#     Default: false
+#
 #   [*autoupgrade*]
 #     Upgrade package automatically, if there is a newer version.
 #     Default: false
@@ -118,6 +122,7 @@
 #
 class supervisor(
   $ensure                   = 'present',
+  $nodaemon                 = false,
   $autoupgrade              = false,
   $service_ensure           = 'running',
   $service_enable           = true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,6 +13,7 @@
 define supervisor::service (
   $command,
   $ensure                   = 'present',
+  $enable                   = true,
   $type                     = 'program',
   $numprocs                 = 1,
   $numprocs_start           = 0,
@@ -59,7 +60,7 @@ define supervisor::service (
       $config_ensure = file
     }
     'stopped': {
-      $autostart = false
+      $autostart = $enable
       $dir_ensure = 'directory'
       $dir_recurse = false
       $dir_force = false

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -2,6 +2,7 @@ class supervisor::update {
   exec { 'supervisor::update':
     command     => '/usr/bin/supervisorctl update',
     logoutput   => on_failure,
+    onlyif      => "test -f $supervisor::unix_server_file",
     refreshonly => true,
     require     => Service[$supervisor::params::system_service],
   }

--- a/templates/supervisord.conf.erb
+++ b/templates/supervisord.conf.erb
@@ -22,7 +22,7 @@ logfile_maxbytes=<%= @logfile_maxbytes %>   ; (max main logfile bytes b4 rotatio
 logfile_backups=<%= @logfile_backups %>     ; (num of main logfile rotation backups;default 10)
 loglevel=<%= @log_level %>                  ; (log level;default info; others: debug,warn,trace)
 pidfile=/var/run/supervisord.pid            ; (supervisord pidfile;default supervisord.pid)
-nodaemon=false                              ; (start in foreground if true;default false)
+nodaemon=<%= @nodaemon %>                   ; (start in foreground if true;default false)
 minfds=<%= @minfds %>                       ; (min. avail startup file descriptors;default 1024)
 minprocs=<%= @minprocs %>                   ; (min. avail process descriptors;default 200)
 childlogdir=<%= @childlogdir %>             ; ('AUTO' child log dir, default $TEMP)


### PR DESCRIPTION
Hi,

* added the nodaemon option as per the Supervisor spec. 
* added a test to ensure supervisorctl is actually running before trying to update it (this is because it does not run during docker builds, only at runtime)
* added the ability to add an autostart service without starting it immediately

The last of those three is the only one I see as potentially changing the behaviour of this module, but only to what is the standard functionality for Puppet services, i.e. enable and ensure should be separate parameters.