### PR TITLE
added systemctl daemon-reload if systemd file changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -239,6 +239,11 @@ class supervisor(
             ensure  => $file_ensure,
             source  => 'puppet:///modules/supervisor/service_redhat',
             require => Package[$supervisor::params::package],
+          } ~>
+
+          exec { 'systemd-daemon-reload':
+            command     => '/usr/bin/systemctl daemon-reload',
+            refreshonly => true,
           }
         }
       }


### PR DESCRIPTION
Minor change to run systemctl daemon-reload if the system unit for supervisord was changed due to the template