### PR TITLE
Fixed regex in process parsing

### DIFF
--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:service).provide :supervisor, :parent => :base do
     #output.lines.map { |line| line.match /^((?<group_name>.+?):)?(?<process_name>(?<program_name>.+?)(_(?<program_num>\d{2}))?) +(?<state>\w+)/ }.reject(&:nil?)
 
     result = output.lines.map { |line|
-      line.match /^((.+?):)?((.+?)(_(\d+))?) +(\w+)/
+      line.match /^(([^\s]+?):)?(([^\s]+?)(_(\d+))?) +(\w+)/
       { :group_name => $2, :process_name => $3, :program_name => $4, :program_num => $6, :state => $7 }
     }
     result.reject(&:nil?)


### PR DESCRIPTION
Old version failed on processes which did not belong to any group, e.g. on 
```
spark-slave                      STOPPED    Sep 19 11:09 PM
```
it gave
```
 {
  :group_name=>"spark-slave                      STOPPED    Sep 19 11", 
  :process_name=>"09", 
  :program_name=>"09", 
  :program_num=>nil, 
  :state=>"PM"
}
```