### PR TITLE
Allow third parties to view files under supervisor directory logs

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -84,7 +84,7 @@ define supervisor::service (
     ensure  => $dir_ensure,
     owner   => $user,
     group   => $group,
-    mode    => '0750',
+    mode    => '0755',
     recurse => $dir_recurse,
     force   => $dir_force,
     require => File['/var/log/supervisor'],


### PR DESCRIPTION
At the moment users such as Logstash cannot view any supervisor created logs because they do not have execute permissions on the log directory supervisor creates.
